### PR TITLE
Fix memory summary formatting bug

### DIFF
--- a/reverie/backend_server/persona/memory_structures/associative_memory.py
+++ b/reverie/backend_server/persona/memory_structures/associative_memory.py
@@ -278,17 +278,19 @@ class AssociativeMemory:
     return ret_set
 
 
-  def get_str_seq_events(self): 
+  def get_str_seq_events(self):
     ret_str = ""
-    for count, event in enumerate(self.seq_event): 
-      ret_str += f'{"Event", len(self.seq_event) - count, ": ", event.spo_summary(), " -- ", event.description}\n'
+    for count, event in enumerate(self.seq_event):
+      ret_str += (f"Event {len(self.seq_event) - count}: "
+                   f"{event.spo_summary()} -- {event.description}\n")
     return ret_str
 
 
-  def get_str_seq_thoughts(self): 
+  def get_str_seq_thoughts(self):
     ret_str = ""
-    for count, event in enumerate(self.seq_thought): 
-      ret_str += f'{"Thought", len(self.seq_thought) - count, ": ", event.spo_summary(), " -- ", event.description}'
+    for count, event in enumerate(self.seq_thought):
+      ret_str += (f"Thought {len(self.seq_thought) - count}: "
+                   f"{event.spo_summary()} -- {event.description}\n")
     return ret_str
 
 


### PR DESCRIPTION
## Summary
- fix associative memory string formatting

## Testing
- `python3 -m py_compile reverie/backend_server/persona/memory_structures/associative_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_683ffd2e9fd0833081011a877fc44c3d