### PR TITLE
Fix typo in scratch memory comments

### DIFF
--- a/reverie/backend_server/persona/memory_structures/scratch.py
+++ b/reverie/backend_server/persona/memory_structures/scratch.py
@@ -327,7 +327,7 @@ class Scratch:
     OUTPUT 
       an integer value for the current index of f_daily_schedule.
     """
-    # We first calculate teh number of minutes elapsed today. 
+    # We first calculate the number of minutes elapsed today.
     today_min_elapsed = 0
     today_min_elapsed += self.curr_time.hour * 60
     today_min_elapsed += self.curr_time.minute
@@ -363,7 +363,7 @@ class Scratch:
     OUTPUT 
       an integer value for the current index of f_daily_schedule.
     """
-    # We first calculate teh number of minutes elapsed today. 
+    # We first calculate the number of minutes elapsed today.
     today_min_elapsed = 0
     today_min_elapsed += self.curr_time.hour * 60
     today_min_elapsed += self.curr_time.minute


### PR DESCRIPTION
## Summary
- fix a typo in `Scratch` comments

## Testing
- `python -m py_compile reverie/backend_server/persona/memory_structures/scratch.py`

------
https://chatgpt.com/codex/tasks/task_e_683ffe88d2248330865b1f3f54f349f2