### PR TITLE
Add landing page test

### DIFF
--- a/environment/frontend_server/translator/tests.py
+++ b/environment/frontend_server/translator/tests.py
@@ -1,3 +1,12 @@
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+
+class TranslatorViewTests(TestCase):
+    """Tests for views in the translator app."""
+
+    def test_landing_page(self):
+        """Landing view should return HTTP 200."""
+        response = self.client.get(reverse("landing"))
+        self.assertEqual(response.status_code, 200)
+


### PR DESCRIPTION
## Summary
- test `landing` view using Django's test client

## Testing
- `python manage.py test translator/tests.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683ffe8d61c883309f0814e973ba309d